### PR TITLE
feature/P2022-13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:17.0.2-slim
+
+WORKDIR /patronage22-eganortap
+
+RUN groupadd appusers
+RUN useradd -ms /bin/bash -G appusers appuser
+
+USER appuser:appusers
+
+ARG JAR_FILE=target/patronage22-eganortap-*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/patronage22-eganortap/app.jar"]


### PR DESCRIPTION
### Dockerfile add
It uses application jar file, so keep in mind to build it first using `mvn package` or `./mvnw package`.
You can build an image using ` docker build -t intive/patronage22-eganortap .` in project root directory.
Then, run the container with `docker run -p 8080:8080 intive/patronage22-eganortap`.
